### PR TITLE
Fix WETH Bug

### DIFF
--- a/src/transform/ui.ts
+++ b/src/transform/ui.ts
@@ -1,6 +1,7 @@
 import {
   ChainData,
   ChainIcons,
+  FungibleImplementation,
   FungibleTokenData,
   NFTPosition,
   PositionData,
@@ -73,8 +74,11 @@ export function transformPositionDataToUserDashboardResponse(
       totalUsdBalance += attributes.value || 0;
       // Get chain icon from zerion.getChains.
       const chainIcon = chain.icon;
-      const contractAddress =
-        attributes.fungible_info.implementations[0]?.address;
+      const contractAddress = findImplementation(
+        chain,
+        attributes.fungible_info.implementations
+      )?.address;
+
       const tokenIcon = attributes.fungible_info.icon?.url;
       // Extract balances and token metadata
       const userToken: UserToken = {
@@ -135,7 +139,9 @@ export function transformPositionDataToUserDashboardResponse(
         meta: {
           name: nativeToken.attributes.name,
           symbol: nativeToken.attributes.symbol,
-          decimals: nativeToken.attributes.implementations[0].decimals,
+          decimals:
+            findImplementation(chain, nativeToken.attributes.implementations)
+              ?.decimals || 18,
           isSpam: false,
           tokenIcon: nativeToken.attributes.icon?.url,
         },
@@ -214,4 +220,11 @@ export function transformNftDataToUserNftResponse(
     chains: Array.from(chainsSet),
     chainsIcons,
   };
+}
+
+function findImplementation(
+  chain: MinChainData,
+  implementations: FungibleImplementation[]
+): FungibleImplementation | undefined {
+  return implementations.find((impl) => impl.chain_id === chain.zerionId);
 }

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -33,7 +33,7 @@ describe("Near Safe Requests", () => {
     console.log("Balances", JSON.stringify(balances, null, 2));
   });
 
-  it.only("ui.getUserBalances", async () => {
+  it.skip("ui.getUserBalances", async () => {
     const zerion = new ZerionAPI(apiKey, false);
     const balances = await zerion.ui.getUserBalances(
       "0x54F08c27e75BeA0cdDdb8aA9D69FD61551B19BbA",

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -33,13 +33,13 @@ describe("Near Safe Requests", () => {
     console.log("Balances", JSON.stringify(balances, null, 2));
   });
 
-  it.skip("ui.getUserBalances", async () => {
+  it.only("ui.getUserBalances", async () => {
     const zerion = new ZerionAPI(apiKey, false);
     const balances = await zerion.ui.getUserBalances(
       "0x54F08c27e75BeA0cdDdb8aA9D69FD61551B19BbA",
       {
         options: {
-          supportedChains: [1, 56, 100, 137, 43114],
+          supportedChains: [100],
           // showZeroNative: true,
           // hideDust: 0.0001,
         },


### PR DESCRIPTION
We were naively retrieving the contract address info from the first element of the implementations array. In this case we were always taking the Arbitrum WETH address (see below).

Now, we actually get the correct implementation by chainId.

```
[
            {
              "chain_id": "arbitrum",
              "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
              "decimals": 18
            },
            {
              "chain_id": "astar-zkevm",
              "address": "0xe9cc37904875b459fa5d0fe37680d36f1ed55e38",
              "decimals": 18
            },
            {
              "chain_id": "aurora",
              "address": "0xc9bdeed33cd01541e1eed10f90519d2c06fe3feb",
              "decimals": 18
            },
            {
              "chain_id": "avalanche",
              "address": "0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab",
              "decimals": 18
            },
            {
              "chain_id": "base",
              "address": "0x4200000000000000000000000000000000000006",
              "decimals": 18
            },
            {
              "chain_id": "binance-smart-chain",
              "address": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
              "decimals": 18
            },
            {
              "chain_id": "blast",
              "address": "0x4300000000000000000000000000000000000004",
              "decimals": 18
            },
            {
              "chain_id": "celo",
              "address": "0x2def4285787d58a2f811af24755a8150622f4361",
              "decimals": 18
            },
            {
              "chain_id": "ethereum",
              "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
              "decimals": 18
            },
            {
              "chain_id": "gravity-alpha",
              "address": "0xf6f832466cd6c21967e0d954109403f36bc8ceaa",
              "decimals": 18
            },
            {
              "chain_id": "linea",
              "address": "0xe5d7c2a44ffddf6b295a15c148167daaaf5cf34f",
              "decimals": 18
            },
            {
              "chain_id": "mantle",
              "address": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead1111",
              "decimals": 18
            },
            {
              "chain_id": "metis-andromeda",
              "address": "0x420000000000000000000000000000000000000a",
              "decimals": 18
            },
            {
              "chain_id": "mode",
              "address": "0x4200000000000000000000000000000000000006",
              "decimals": 18
            },
            {
              "chain_id": "optimism",
              "address": "0x4200000000000000000000000000000000000006",
              "decimals": 18
            },
            {
              "chain_id": "polygon",
              "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
              "decimals": 18
            },
            {
              "chain_id": "polygon-zkevm",
              "address": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
              "decimals": 18
            },
            {
              "chain_id": "scroll",
              "address": "0x5300000000000000000000000000000000000004",
              "decimals": 18
            },
            {
              "chain_id": "tomochain",
              "address": "0x2eaa73bd0db20c64f53febea7b5f5e5bccc7fb8b",
              "decimals": 18
            },
            {
              "chain_id": "world",
              "address": "0x4200000000000000000000000000000000000006",
              "decimals": 18
            },
            {
              "chain_id": "xdai",
              "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
              "decimals": 18
            },
            {
              "chain_id": "zero",
              "address": "0xac98b49576b1c892ba6bfae08fe1bb0d80cf599c",
              "decimals": 18
            },
            {
              "chain_id": "zksync-era",
              "address": "0x5aea5775959fbc2557cc8789bc1bf90a239d9a91",
              "decimals": 18
            },
            {
              "chain_id": "zora",
              "address": "0x4200000000000000000000000000000000000006",
              "decimals": 18
            }
          ]
```