### PR TITLE
Fix: Project File Pointers

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "zerion"
   ],
   "license": "MIT",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist/cjs/src/index.js",
+  "module": "dist/esm/src/index.js",
+  "types": "dist/esm/src/index.d.ts",
   "files": [
     "dist/**/*"
   ],


### PR DESCRIPTION
#13 - introduced a new build directory structure than previous versions.

This is causing confusion and users would have to manually import as


```
import { ZerionAPI } from "zerion-sdk/dist/cjs/src";
```

instead of 
```
import { ZerionAPI } from "zerion-sdk";
```