### PR TITLE
Override Polygon Native Asset

### DIFF
--- a/data/mainnet-chains.json
+++ b/data/mainnet-chains.json
@@ -1636,6 +1636,56 @@
   },
   {
     "type": "chains",
+    "id": "world",
+    "attributes": {
+      "external_id": "0x1e0",
+      "name": "World Chain",
+      "icon": {
+        "url": "https://protocol-icons.s3.amazonaws.com/worldchain.png"
+      },
+      "explorer": {
+        "name": "WorldScan",
+        "token_url_format": "https://worldchain-mainnet.explorer.alchemy.com/token/{ADDRESS}",
+        "tx_url_format": "https://worldchain-mainnet.explorer.alchemy.com/tx/{HASH}",
+        "home_url": "https://worldchain-mainnet.explorer.alchemy.com/"
+      },
+      "rpc": {
+        "public_servers_url": [
+          "https://worldchain-mainnet.g.alchemy.com/public"
+        ]
+      },
+      "flags": {
+        "supports_trading": true,
+        "supports_sending": true,
+        "supports_bridge": false
+      }
+    },
+    "relationships": {
+      "native_fungible": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth"
+        },
+        "data": {
+          "type": "fungibles",
+          "id": "eth"
+        }
+      },
+      "wrapped_native_fungible": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        },
+        "data": {
+          "type": "fungibles",
+          "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        }
+      }
+    },
+    "links": {
+      "self": "https://api.zerion.io/v1/chains/world"
+    }
+  },
+  {
+    "type": "chains",
     "id": "tomochain",
     "attributes": {
       "external_id": "0x58",
@@ -1673,6 +1723,56 @@
     },
     "links": {
       "self": "https://api.zerion.io/v1/chains/tomochain"
+    }
+  },
+  {
+    "type": "chains",
+    "id": "zero",
+    "attributes": {
+      "external_id": "0x849ea",
+      "name": "ZERϴ",
+      "icon": {
+        "url": "https://chain-icons.s3.amazonaws.com/chainlist/543210"
+      },
+      "explorer": {
+        "name": "ZERϴ Explorer",
+        "token_url_format": "https://explorer.zero.network/token/{ADDRESS}",
+        "tx_url_format": "https://explorer.zero.network/tx/{HASH}",
+        "home_url": "https://explorer.zero.network"
+      },
+      "rpc": {
+        "public_servers_url": [
+          "https://rpc.zerion.io/v1/zero"
+        ]
+      },
+      "flags": {
+        "supports_trading": true,
+        "supports_sending": true,
+        "supports_bridge": true
+      }
+    },
+    "relationships": {
+      "native_fungible": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth"
+        },
+        "data": {
+          "type": "fungibles",
+          "id": "eth"
+        }
+      },
+      "wrapped_native_fungible": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        },
+        "data": {
+          "type": "fungibles",
+          "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        }
+      }
+    },
+    "links": {
+      "self": "https://api.zerion.io/v1/chains/zero"
     }
   },
   {
@@ -1728,123 +1828,23 @@
   },
   {
     "type": "chains",
-    "id": "world",
+    "id": "zklink-nova",
     "attributes": {
-      "external_id": "0x1e0",
-      "name": "World Chain",
+      "external_id": "0xc5cc4",
+      "name": "ZkLink Nova",
       "icon": {
-        "url": "https://protocol-icons.s3.amazonaws.com/worldchain.png"
+        "url": "https://chain-icons.s3.amazonaws.com/zklink.png"
       },
       "explorer": {
-        "name": "WorldScan",
-        "token_url_format": "https://worldchain-mainnet.explorer.alchemy.com/token/{ADDRESS}",
-        "tx_url_format": "https://worldchain-mainnet.explorer.alchemy.com/tx/{HASH}",
-        "home_url": "https://worldchain-mainnet.explorer.alchemy.com/"
+        "name": "zkLink Nova Block Explorer",
+        "token_url_format": "https://explorer.zklink.io/token/{ADDRESS}",
+        "tx_url_format": "https://explorer.zklink.io/tx/{HASH}",
+        "home_url": "https://explorer.zklink.io"
       },
       "rpc": {
         "public_servers_url": [
-          "https://worldchain-mainnet.g.alchemy.com/public"
-        ]
-      },
-      "flags": {
-        "supports_trading": true,
-        "supports_sending": true,
-        "supports_bridge": false
-      }
-    },
-    "relationships": {
-      "native_fungible": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth"
-        },
-        "data": {
-          "type": "fungibles",
-          "id": "eth"
-        }
-      },
-      "wrapped_native_fungible": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-        },
-        "data": {
-          "type": "fungibles",
-          "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-        }
-      }
-    },
-    "links": {
-      "self": "https://api.zerion.io/v1/chains/world"
-    }
-  },
-  {
-    "type": "chains",
-    "id": "zero",
-    "attributes": {
-      "external_id": "0x849ea",
-      "name": "ZERϴ",
-      "icon": {
-        "url": "https://chain-icons.s3.amazonaws.com/chainlist/543210"
-      },
-      "explorer": {
-        "name": "ZERϴ Explorer",
-        "token_url_format": "https://explorer.zero.network/token/{ADDRESS}",
-        "tx_url_format": "https://explorer.zero.network/tx/{HASH}",
-        "home_url": "https://explorer.zero.network"
-      },
-      "rpc": {
-        "public_servers_url": [
-          "https://rpc.zerion.io/v1/zero"
-        ]
-      },
-      "flags": {
-        "supports_trading": true,
-        "supports_sending": true,
-        "supports_bridge": true
-      }
-    },
-    "relationships": {
-      "native_fungible": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth"
-        },
-        "data": {
-          "type": "fungibles",
-          "id": "eth"
-        }
-      },
-      "wrapped_native_fungible": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-        },
-        "data": {
-          "type": "fungibles",
-          "id": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-        }
-      }
-    },
-    "links": {
-      "self": "https://api.zerion.io/v1/chains/zero"
-    }
-  },
-  {
-    "type": "chains",
-    "id": "re-al",
-    "attributes": {
-      "external_id": "0x1b254",
-      "name": "re.al",
-      "icon": {
-        "url": "https://chain-icons.s3.us-east-1.amazonaws.com/real.png"
-      },
-      "explorer": {
-        "name": "blockscout",
-        "token_url_format": "https://explorer.re.al/token/{ADDRESS}",
-        "tx_url_format": "https://explorer.re.al/tx/{HASH}",
-        "home_url": "https://explorer.re.al"
-      },
-      "rpc": {
-        "public_servers_url": [
-          "https://real.drpc.org",
-          "wss://real.drpc.org"
+          "https://rpc.zklink.io",
+          "wss://rpc.zklink.io"
         ]
       },
       "flags": {
@@ -1856,16 +1856,16 @@
     "relationships": {
       "native_fungible": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf"
+          "related": "https://api.zerion.io/v1/fungibles/eth"
         },
         "data": {
           "type": "fungibles",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf"
+          "id": "eth"
         }
       }
     },
     "links": {
-      "self": "https://api.zerion.io/v1/chains/re-al"
+      "self": "https://api.zerion.io/v1/chains/zklink-nova"
     }
   },
   {
@@ -1920,23 +1920,23 @@
   },
   {
     "type": "chains",
-    "id": "zklink-nova",
+    "id": "re-al",
     "attributes": {
-      "external_id": "0xc5cc4",
-      "name": "ZkLink Nova",
+      "external_id": "0x1b254",
+      "name": "re.al",
       "icon": {
-        "url": "https://chain-icons.s3.amazonaws.com/zklink.png"
+        "url": "https://chain-icons.s3.us-east-1.amazonaws.com/real.png"
       },
       "explorer": {
-        "name": "zkLink Nova Block Explorer",
-        "token_url_format": "https://explorer.zklink.io/token/{ADDRESS}",
-        "tx_url_format": "https://explorer.zklink.io/tx/{HASH}",
-        "home_url": "https://explorer.zklink.io"
+        "name": "blockscout",
+        "token_url_format": "https://explorer.re.al/token/{ADDRESS}",
+        "tx_url_format": "https://explorer.re.al/tx/{HASH}",
+        "home_url": "https://explorer.re.al"
       },
       "rpc": {
         "public_servers_url": [
-          "https://rpc.zklink.io",
-          "wss://rpc.zklink.io"
+          "https://real.drpc.org",
+          "wss://real.drpc.org"
         ]
       },
       "flags": {
@@ -1948,16 +1948,16 @@
     "relationships": {
       "native_fungible": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth"
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf"
         },
         "data": {
           "type": "fungibles",
-          "id": "eth"
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf"
         }
       }
     },
     "links": {
-      "self": "https://api.zerion.io/v1/chains/zklink-nova"
+      "self": "https://api.zerion.io/v1/chains/re-al"
     }
   }
 ]

--- a/data/mainnet-native-tokens.json
+++ b/data/mainnet-native-tokens.json
@@ -138,14 +138,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -266,14 +266,14 @@
       "market_data": {
         "total_supply": 145887575.79,
         "circulating_supply": 145887575.79,
-        "market_cap": 90027654884.79938,
-        "fully_diluted_valuation": 90027654884.79938,
-        "price": 617.1029602575,
+        "market_cap": 93386881051.03252,
+        "fully_diluted_valuation": 93386881051.03252,
+        "price": 640.1290894398,
         "changes": {
-          "percent_1d": -2.3027348764314888,
-          "percent_30d": 3.2456638424547615,
-          "percent_90d": 8.351970856132917,
-          "percent_365d": 153.59480505578227
+          "percent_1d": -3.149109944514613,
+          "percent_30d": 8.309705332175907,
+          "percent_90d": 13.753316547842358,
+          "percent_365d": 173.84035984571636
         }
       }
     },
@@ -473,14 +473,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -680,14 +680,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -887,14 +887,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -1003,16 +1003,16 @@
         }
       ],
       "market_data": {
-        "total_supply": 49999999999.99999,
-        "circulating_supply": null,
-        "market_cap": null,
-        "fully_diluted_valuation": 1745085567575,
-        "price": 34.901711351500005,
+        "total_supply": 447524810.50067496,
+        "circulating_supply": 409188506.92265296,
+        "market_cap": 15970234511.338709,
+        "fully_diluted_valuation": 17466463628.43513,
+        "price": 39.029039773,
         "changes": {
-          "percent_1d": -4.434628748175472,
-          "percent_30d": 25.21225576171766,
-          "percent_90d": 58.02251076916683,
-          "percent_365d": 64.7232976321738
+          "percent_1d": -7.8213026484485235,
+          "percent_30d": 47.38671140526059,
+          "percent_90d": 46.16518813395254,
+          "percent_365d": 87.45305155268855
         }
       }
     },
@@ -1133,14 +1133,14 @@
       "market_data": {
         "total_supply": 145887575.79,
         "circulating_supply": 145887575.79,
-        "market_cap": 90027654884.79938,
-        "fully_diluted_valuation": 90027654884.79938,
-        "price": 617.1029602575,
+        "market_cap": 93386881051.03252,
+        "fully_diluted_valuation": 93386881051.03252,
+        "price": 640.1290894398,
         "changes": {
-          "percent_1d": -2.3027348764314888,
-          "percent_30d": 3.2456638424547615,
-          "percent_90d": 8.351970856132917,
-          "percent_365d": 153.59480505578227
+          "percent_1d": -3.149109944514613,
+          "percent_30d": 8.309705332175907,
+          "percent_90d": 13.753316547842358,
+          "percent_365d": 173.84035984571636
         }
       }
     },
@@ -1340,14 +1340,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -1547,14 +1547,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -1754,14 +1754,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -1961,14 +1961,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -2073,14 +2073,14 @@
       ],
       "market_data": {
         "total_supply": 36965935954,
-        "circulating_supply": 17145337963.22,
-        "market_cap": 402405013.4227684,
-        "fully_diluted_valuation": 867598993.1294943,
-        "price": 0.023470229300000003,
+        "circulating_supply": 17145837963.220001,
+        "market_cap": 303865333.5651859,
+        "fully_diluted_valuation": 655124962.880613,
+        "price": 0.0177223962,
         "changes": {
-          "percent_1d": -0.16700786218604532,
-          "percent_30d": 161.62426730314945,
-          "percent_90d": 405.79692785783516,
+          "percent_1d": -12.745658167010912,
+          "percent_30d": 135.79551012383922,
+          "percent_90d": 301.7965813910539,
           "percent_365d": null
         }
       }
@@ -2218,16 +2218,16 @@
         }
       ],
       "market_data": {
-        "total_supply": 157028.669163053,
-        "circulating_supply": 157028.669163053,
-        "market_cap": 482805514.8271225,
-        "fully_diluted_valuation": 482805514.8271225,
-        "price": 3074.6329151258,
+        "total_supply": 153796.66471282998,
+        "circulating_supply": 153796.66471282998,
+        "market_cap": 509317555.8236246,
+        "fully_diluted_valuation": 509317555.8236246,
+        "price": 3311.6293957,
         "changes": {
-          "percent_1d": -1.2012637932081922,
-          "percent_30d": 16.582797268395282,
-          "percent_90d": 15.998262726608244,
-          "percent_365d": 57.400929377855995
+          "percent_1d": -1.109191783933871,
+          "percent_30d": 30.727002129982917,
+          "percent_90d": 20.991226349071805,
+          "percent_365d": 59.72915134492508
         }
       }
     },
@@ -2348,13 +2348,13 @@
       "market_data": {
         "total_supply": 12000000000,
         "circulating_supply": 7232700000,
-        "market_cap": 223958133.99204,
-        "fully_diluted_valuation": 371575982.40000004,
-        "price": 0.0309646652,
+        "market_cap": 220795562.1435,
+        "fully_diluted_valuation": 366328860,
+        "price": 0.030527405,
         "changes": {
-          "percent_1d": -0.3586612116404505,
-          "percent_30d": -6.265024699924958,
-          "percent_90d": -24.21894393829148,
+          "percent_1d": -2.2817414811164305,
+          "percent_30d": -3.122503369651164,
+          "percent_90d": -29.0258977289937,
           "percent_365d": null
         }
       }
@@ -2555,14 +2555,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -2762,14 +2762,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -2969,14 +2969,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -3092,14 +3092,14 @@
       "market_data": {
         "total_supply": 6219316794.99,
         "circulating_supply": 3366841707.8368397,
-        "market_cap": 2420977727.9465227,
-        "fully_diluted_valuation": 4472092468.341314,
-        "price": 0.7190649095,
+        "market_cap": 2689860545.799934,
+        "fully_diluted_valuation": 4968779740.887422,
+        "price": 0.7989269408,
         "changes": {
-          "percent_1d": -0.6601342105165464,
-          "percent_30d": 16.82349598091706,
-          "percent_90d": 19.27541554941955,
-          "percent_365d": 44.33592566542894
+          "percent_1d": -5.927813642804519,
+          "percent_30d": 33.598786949472895,
+          "percent_90d": 26.91805678341736,
+          "percent_365d": 57.04279007801035
         }
       }
     },
@@ -3299,14 +3299,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -3409,27 +3409,22 @@
       ],
       "implementations": [
         {
-          "chain_id": "ethereum",
-          "address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
-          "decimals": 18
-        },
-        {
           "chain_id": "polygon",
-          "address": "0x0000000000000000000000000000000000001010",
+          "address": null,
           "decimals": 18
         }
       ],
       "market_data": {
-        "total_supply": 10293340888.2509,
-        "circulating_supply": 7778936907.686185,
-        "market_cap": 3258971764.7442822,
-        "fully_diluted_valuation": 4312376834.751261,
-        "price": 0.4189482192,
+        "total_supply": 10305820741.1794,
+        "circulating_supply": 7976116289.70179,
+        "market_cap": 4203789693.5527864,
+        "fully_diluted_valuation": 5431653882.893961,
+        "price": 0.5270471919999999,
         "changes": {
-          "percent_1d": 2.1516311346273826,
-          "percent_30d": 12.419655307136411,
-          "percent_90d": -5.122164150663008,
-          "percent_365d": -49.358128870868576
+          "percent_1d": -3.4202561986685187,
+          "percent_30d": 50.15921761120149,
+          "percent_90d": 1.295108557937913,
+          "percent_365d": -31.730864383130747
         }
       }
     },
@@ -3535,14 +3530,14 @@
       "market_data": {
         "total_supply": 1000000000,
         "circulating_supply": 553833395,
-        "market_cap": 366129989.3095514,
-        "fully_diluted_valuation": 661083265.5000001,
-        "price": 0.6610832655000001,
+        "market_cap": 424633148.58644485,
+        "fully_diluted_valuation": 766716403.2,
+        "price": 0.7667164032,
         "changes": {
-          "percent_1d": 1.3920569089338224,
-          "percent_30d": -23.572953014908617,
-          "percent_90d": 42.744574742828455,
-          "percent_365d": 24.113744462658236
+          "percent_1d": -3.2378040884050616,
+          "percent_30d": 12.938788075188988,
+          "percent_90d": 49.98784384999218,
+          "percent_365d": 38.751958463167114
         }
       }
     },
@@ -3742,14 +3737,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -3858,16 +3853,16 @@
         }
       ],
       "market_data": {
-        "total_supply": null,
+        "total_supply": 78900324.61324899,
         "circulating_supply": null,
         "market_cap": null,
-        "fully_diluted_valuation": null,
-        "price": 1.0036684259,
+        "fully_diluted_valuation": 78651278.34231798,
+        "price": 0.9968435330000001,
         "changes": {
-          "percent_1d": 0.5035649865135401,
-          "percent_30d": 0.3351665371198339,
-          "percent_90d": 0.17163253009434873,
-          "percent_365d": 1.2548254196140858
+          "percent_1d": -0.21397018393466777,
+          "percent_30d": -0.5740717390967882,
+          "percent_90d": -0.3145198752697624,
+          "percent_365d": 0.5082705153394618
         }
       }
     },
@@ -3973,24 +3968,19 @@
           "chain_id": "fantom",
           "address": null,
           "decimals": 18
-        },
-        {
-          "chain_id": "solana",
-          "address": "8gC27rQF4NEDYfyf5aS8ZmQJUum5gufowKGYRRba4ENN",
-          "decimals": 8
         }
       ],
       "market_data": {
         "total_supply": 3175000000,
-        "circulating_supply": 2541152731.01,
-        "market_cap": 1784854261.0852954,
-        "fully_diluted_valuation": 2230055757.685,
-        "price": 0.7023797662,
+        "circulating_supply": 2803634835.52659,
+        "market_cap": 2388035511.943312,
+        "fully_diluted_valuation": 2704351028.295,
+        "price": 0.8517641034,
         "changes": {
-          "percent_1d": -4.404530299425785,
-          "percent_30d": -2.718105432026678,
-          "percent_90d": 76.91313186609389,
-          "percent_365d": 119.6902948797558
+          "percent_1d": -0.71666174299401,
+          "percent_30d": 24.56263330841912,
+          "percent_90d": 69.69921390780159,
+          "percent_365d": 168.6185242062375
         }
       }
     },
@@ -4280,14 +4270,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -4487,14 +4477,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -4605,14 +4595,14 @@
       "market_data": {
         "total_supply": 10000000,
         "circulating_supply": 6101334.342,
-        "market_cap": 274646141.3311026,
-        "fully_diluted_valuation": 450141110.02,
-        "price": 45.014111002,
+        "market_cap": 321293274.3809843,
+        "fully_diluted_valuation": 526595096.04200006,
+        "price": 52.659509604200004,
         "changes": {
-          "percent_1d": -3.142859586501886,
-          "percent_30d": -2.908064745778415,
-          "percent_90d": 41.47353072239457,
-          "percent_365d": 151.68899279202176
+          "percent_1d": 2.1085925835198447,
+          "percent_30d": 20.488117287726926,
+          "percent_90d": 36.096487153058014,
+          "percent_365d": 180.26858452035952
         }
       }
     },
@@ -4728,14 +4718,14 @@
       "market_data": {
         "total_supply": 1000000000,
         "circulating_supply": 721448863,
-        "market_cap": 807712526.1302595,
-        "fully_diluted_valuation": 1119570031.3000002,
-        "price": 1.1195700313,
+        "market_cap": 908244367.8335868,
+        "fully_diluted_valuation": 1258917179.6000001,
+        "price": 1.2589171796,
         "changes": {
-          "percent_1d": 1.4063690768718764,
-          "percent_30d": 51.42836880722946,
-          "percent_90d": 85.95486050618545,
-          "percent_365d": -16.32511164442948
+          "percent_1d": -0.41815526889489196,
+          "percent_30d": 10.208458592505266,
+          "percent_90d": 76.41375693981986,
+          "percent_365d": -25.14138025119551
         }
       }
     },
@@ -4847,8 +4837,8 @@
         }
       ],
       "market_data": {
-        "total_supply": 141959558.245375,
-        "circulating_supply": 141959558.245375,
+        "total_supply": 139094398.92659798,
+        "circulating_supply": 139094398.92659798,
         "market_cap": null,
         "fully_diluted_valuation": null,
         "price": null,
@@ -5056,14 +5046,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -5263,14 +5253,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -5470,14 +5460,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -5677,14 +5667,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -5884,14 +5874,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -5948,214 +5938,6 @@
         "data": {
           "type": "fungible_charts",
           "id": "eth-year"
-        }
-      }
-    }
-  },
-  "tomochain": {
-    "type": "fungibles",
-    "id": "2912694c-c696-4549-acfb-f43a87938623",
-    "attributes": {
-      "name": "Viction",
-      "symbol": "VIC",
-      "description": null,
-      "icon": null,
-      "flags": {
-        "verified": false
-      },
-      "external_links": [],
-      "implementations": [
-        {
-          "chain_id": "tomochain",
-          "address": null,
-          "decimals": 18
-        }
-      ],
-      "market_data": {
-        "total_supply": null,
-        "circulating_supply": null,
-        "market_cap": null,
-        "fully_diluted_valuation": null,
-        "price": 0.3608123687,
-        "changes": {
-          "percent_1d": -10.000958152628451,
-          "percent_30d": -0.3439633103975623,
-          "percent_90d": null,
-          "percent_365d": null
-        }
-      }
-    },
-    "relationships": {
-      "chart_day": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/day?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "2912694c-c696-4549-acfb-f43a87938623-day"
-        }
-      },
-      "chart_hour": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/hour?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "2912694c-c696-4549-acfb-f43a87938623-hour"
-        }
-      },
-      "chart_max": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/max?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "2912694c-c696-4549-acfb-f43a87938623-max"
-        }
-      },
-      "chart_month": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/month?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "2912694c-c696-4549-acfb-f43a87938623-month"
-        }
-      },
-      "chart_week": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/week?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "2912694c-c696-4549-acfb-f43a87938623-week"
-        }
-      },
-      "chart_year": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/year?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "2912694c-c696-4549-acfb-f43a87938623-year"
-        }
-      }
-    }
-  },
-  "okbchain": {
-    "type": "fungibles",
-    "id": "0x75231f58b43240c9718dd58b4967c5114342a86c",
-    "attributes": {
-      "name": "OKB",
-      "symbol": "OKB",
-      "description": "<a href=\"https://www.coingecko.com/en/exchanges/okex\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">OKEx</a>, the 2nd most popular cryptocurrency exchange by trading volume, launched its platform token ‘OKB‘ today with 10 trading pairs. On its official support page, OKEx describes OKB is a global utility token issued by the OK Blockchain Foundation. The total available supply of OKB will be one billion tokens (1,000,000,000), with a distribution model that allocates 60% of the supply will be given out to OKEx customers for community building and during marketing campaigns. According to OKEx, the company had officially issued OKB on ERC20 protocol earlier this month. \r\n\r\nThe company denied ICO (initial coin offering) and public fundraising. Reportedly the company had stated that it would be soon shifting the token to its official OK chain and subsequently it will be applied not only on OKEx’s platform but also on other related projects. There will be in total 1 billion tokens supplied globally out of which 600 million coins will be distributed to OKEx customers for community building and marketing campaigns. Rest will be locked up for a period of 1 year to 3 years.\r\n\r\nAccording to OKEx, the company had officially issued OKB on ERC20 protocol earlier this month. The company denied ICO (initial coin offering) and public fundraising. Reportedly the company had stated that it would be soon shifting the token to its official OK chain and subsequently it will be applied not only on OKEx’s platform but also on other related projects. There will be in total 1 billion tokens supplied globally out of which 600 million coins will be distributed to OKEx customers for community building and marketing campaigns. Rest will be locked up for a period of 1 year to 3 years.",
-      "icon": {
-        "url": "https://cdn.zerion.io/0x75231f58b43240c9718dd58b4967c5114342a86c.png"
-      },
-      "flags": {
-        "verified": true
-      },
-      "external_links": [
-        {
-          "type": "website",
-          "name": "Website",
-          "url": "https://www.okex.com/okb"
-        },
-        {
-          "type": "twitter",
-          "name": "Twitter",
-          "url": "https://twitter.com/OKEx"
-        },
-        {
-          "type": "coingecko",
-          "name": "Coingecko",
-          "url": "https://www.coingecko.com/en/coins/okb"
-        },
-        {
-          "type": "dex.guru",
-          "name": "Dex.guru",
-          "url": "https://dex.guru/token/eth/0x75231f58b43240c9718dd58b4967c5114342a86c"
-        }
-      ],
-      "implementations": [
-        {
-          "chain_id": "ethereum",
-          "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
-          "decimals": 18
-        },
-        {
-          "chain_id": "okbchain",
-          "address": null,
-          "decimals": 18
-        }
-      ],
-      "market_data": {
-        "total_supply": 235957685.3,
-        "circulating_supply": 60000000,
-        "market_cap": 2649856738.83,
-        "fully_diluted_valuation": 10420901041.182224,
-        "price": 44.1642789805,
-        "changes": {
-          "percent_1d": -2.542724828040282,
-          "percent_30d": 9.16398217472902,
-          "percent_90d": 17.283657075696446,
-          "percent_365d": -22.820402538553346
-        }
-      }
-    },
-    "relationships": {
-      "chart_day": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/day?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-day"
-        }
-      },
-      "chart_hour": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/hour?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-hour"
-        }
-      },
-      "chart_max": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/max?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-max"
-        }
-      },
-      "chart_month": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/month?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-month"
-        }
-      },
-      "chart_week": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/week?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-week"
-        }
-      },
-      "chart_year": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/year?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-year"
         }
       }
     }
@@ -6299,14 +6081,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -6363,6 +6145,117 @@
         "data": {
           "type": "fungible_charts",
           "id": "eth-year"
+        }
+      }
+    }
+  },
+  "tomochain": {
+    "type": "fungibles",
+    "id": "2912694c-c696-4549-acfb-f43a87938623",
+    "attributes": {
+      "name": "Viction",
+      "symbol": "VIC",
+      "description": "",
+      "icon": null,
+      "flags": {
+        "verified": false
+      },
+      "external_links": [
+        {
+          "type": "website",
+          "name": "Website",
+          "url": "https://viction.xyz/"
+        },
+        {
+          "type": "twitter",
+          "name": "Twitter",
+          "url": "https://twitter.com/BuildOnViction"
+        },
+        {
+          "type": "discord",
+          "name": "Discord",
+          "url": "https://discord.com/invite/vCEJV44knr"
+        },
+        {
+          "type": "coingecko",
+          "name": "https://www.coingecko.com/en/coins/tomochain",
+          "url": "Coingecko"
+        }
+      ],
+      "implementations": [
+        {
+          "chain_id": "tomochain",
+          "address": null,
+          "decimals": 18
+        }
+      ],
+      "market_data": {
+        "total_supply": 210000000,
+        "circulating_supply": 98606528.65,
+        "market_cap": 39487334.293298766,
+        "fully_diluted_valuation": 84095245.164,
+        "price": 0.4004535484,
+        "changes": {
+          "percent_1d": -3.9644550044903424,
+          "percent_30d": 14.647550454154814,
+          "percent_90d": null,
+          "percent_365d": null
+        }
+      }
+    },
+    "relationships": {
+      "chart_day": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/day?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "2912694c-c696-4549-acfb-f43a87938623-day"
+        }
+      },
+      "chart_hour": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/hour?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "2912694c-c696-4549-acfb-f43a87938623-hour"
+        }
+      },
+      "chart_max": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/max?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "2912694c-c696-4549-acfb-f43a87938623-max"
+        }
+      },
+      "chart_month": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/month?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "2912694c-c696-4549-acfb-f43a87938623-month"
+        }
+      },
+      "chart_week": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/week?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "2912694c-c696-4549-acfb-f43a87938623-week"
+        }
+      },
+      "chart_year": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/2912694c-c696-4549-acfb-f43a87938623/charts/year?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "2912694c-c696-4549-acfb-f43a87938623-year"
         }
       }
     }
@@ -6506,14 +6399,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -6574,304 +6467,120 @@
       }
     }
   },
-  "re-al": {
+  "okbchain": {
     "type": "fungibles",
-    "id": "3b5814a4-7fa3-48e3-b389-638925def2cf",
+    "id": "0x75231f58b43240c9718dd58b4967c5114342a86c",
     "attributes": {
-      "name": "Real Ether",
-      "symbol": "reETH",
-      "description": null,
-      "icon": null,
-      "flags": {
-        "verified": false
-      },
-      "external_links": [],
-      "implementations": [
-        {
-          "chain_id": "ethereum",
-          "address": "0xc0cc5ea00cae0894b441e3b5a3bb57aa92f15421",
-          "decimals": 18
-        },
-        {
-          "chain_id": "re-al",
-          "address": null,
-          "decimals": 18
-        }
-      ],
-      "market_data": {
-        "total_supply": null,
-        "circulating_supply": null,
-        "market_cap": null,
-        "fully_diluted_valuation": null,
-        "price": 3135.0074597651246,
-        "changes": {
-          "percent_1d": -0.9437490872874407,
-          "percent_30d": null,
-          "percent_90d": null,
-          "percent_365d": null
-        }
-      }
-    },
-    "relationships": {
-      "chart_day": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/day?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-day"
-        }
-      },
-      "chart_hour": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/hour?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-hour"
-        }
-      },
-      "chart_max": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/max?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-max"
-        }
-      },
-      "chart_month": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/month?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-month"
-        }
-      },
-      "chart_week": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/week?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-week"
-        }
-      },
-      "chart_year": {
-        "links": {
-          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/year?currency=usd"
-        },
-        "data": {
-          "type": "fungible_charts",
-          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-year"
-        }
-      }
-    }
-  },
-  "zora": {
-    "type": "fungibles",
-    "id": "eth",
-    "attributes": {
-      "name": "Ethereum",
-      "symbol": "ETH",
-      "description": "Ethereum is a global, open-source platform for decentralized applications. In other words, the vision is to create a world computer that anyone can build applications in a decentralized manner; while all states and data are distributed and publicly accessible. Ethereum supports smart contracts in which developers can write code in order to program digital value. Examples of decentralized apps (dapps) built on Ethereum include token, non-fungible tokens, decentralized finance apps, lending protocol, decentralized exchanges, and much more.",
+      "name": "OKB",
+      "symbol": "OKB",
+      "description": "<a href=\"https://www.coingecko.com/en/exchanges/okex\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">OKEx</a>, the 2nd most popular cryptocurrency exchange by trading volume, launched its platform token ‘OKB‘ today with 10 trading pairs. On its official support page, OKEx describes OKB is a global utility token issued by the OK Blockchain Foundation. The total available supply of OKB will be one billion tokens (1,000,000,000), with a distribution model that allocates 60% of the supply will be given out to OKEx customers for community building and during marketing campaigns. According to OKEx, the company had officially issued OKB on ERC20 protocol earlier this month. \r\n\r\nThe company denied ICO (initial coin offering) and public fundraising. Reportedly the company had stated that it would be soon shifting the token to its official OK chain and subsequently it will be applied not only on OKEx’s platform but also on other related projects. There will be in total 1 billion tokens supplied globally out of which 600 million coins will be distributed to OKEx customers for community building and marketing campaigns. Rest will be locked up for a period of 1 year to 3 years.\r\n\r\nAccording to OKEx, the company had officially issued OKB on ERC20 protocol earlier this month. The company denied ICO (initial coin offering) and public fundraising. Reportedly the company had stated that it would be soon shifting the token to its official OK chain and subsequently it will be applied not only on OKEx’s platform but also on other related projects. There will be in total 1 billion tokens supplied globally out of which 600 million coins will be distributed to OKEx customers for community building and marketing campaigns. Rest will be locked up for a period of 1 year to 3 years.",
       "icon": {
-        "url": "https://cdn.zerion.io/eth.png"
+        "url": "https://cdn.zerion.io/0x75231f58b43240c9718dd58b4967c5114342a86c.png"
       },
       "flags": {
         "verified": true
       },
-      "external_links": [],
+      "external_links": [
+        {
+          "type": "website",
+          "name": "Website",
+          "url": "https://www.okex.com/okb"
+        },
+        {
+          "type": "twitter",
+          "name": "Twitter",
+          "url": "https://twitter.com/OKEx"
+        },
+        {
+          "type": "coingecko",
+          "name": "Coingecko",
+          "url": "https://www.coingecko.com/en/coins/okb"
+        },
+        {
+          "type": "dex.guru",
+          "name": "Dex.guru",
+          "url": "https://dex.guru/token/eth/0x75231f58b43240c9718dd58b4967c5114342a86c"
+        }
+      ],
       "implementations": [
         {
-          "chain_id": "arbitrum",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "astar-zkevm",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "aurora",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "base",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "blast",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "bob",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "cyber",
-          "address": null,
-          "decimals": 18
-        },
-        {
           "chain_id": "ethereum",
-          "address": null,
+          "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
           "decimals": 18
         },
         {
-          "chain_id": "linea",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "lisk",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "manta-pacific",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "mode",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "optimism",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "polygon-zkevm",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "polynomial",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "rari",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "redstone",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "scroll",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "taiko",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "world",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "zero",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "zklink-nova",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "zksync-era",
-          "address": null,
-          "decimals": 18
-        },
-        {
-          "chain_id": "zora",
+          "chain_id": "okbchain",
           "address": null,
           "decimals": 18
         }
       ],
       "market_data": {
-        "total_supply": 122373866.2178,
-        "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "total_supply": 235957685.3,
+        "circulating_supply": 60000000,
+        "market_cap": 3106003396.1400003,
+        "fully_diluted_valuation": 12214756198.11889,
+        "price": 51.766723269,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": 2.7677698928369003,
+          "percent_30d": 31.726424373114583,
+          "percent_90d": 34.02264910725924,
+          "percent_365d": -11.288421640874695
         }
       }
     },
     "relationships": {
       "chart_day": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth/charts/day?currency=usd"
+          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/day?currency=usd"
         },
         "data": {
           "type": "fungible_charts",
-          "id": "eth-day"
+          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-day"
         }
       },
       "chart_hour": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth/charts/hour?currency=usd"
+          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/hour?currency=usd"
         },
         "data": {
           "type": "fungible_charts",
-          "id": "eth-hour"
+          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-hour"
         }
       },
       "chart_max": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth/charts/max?currency=usd"
+          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/max?currency=usd"
         },
         "data": {
           "type": "fungible_charts",
-          "id": "eth-max"
+          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-max"
         }
       },
       "chart_month": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth/charts/month?currency=usd"
+          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/month?currency=usd"
         },
         "data": {
           "type": "fungible_charts",
-          "id": "eth-month"
+          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-month"
         }
       },
       "chart_week": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth/charts/week?currency=usd"
+          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/week?currency=usd"
         },
         "data": {
           "type": "fungible_charts",
-          "id": "eth-week"
+          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-week"
         }
       },
       "chart_year": {
         "links": {
-          "related": "https://api.zerion.io/v1/fungibles/eth/charts/year?currency=usd"
+          "related": "https://api.zerion.io/v1/fungibles/0x75231f58b43240c9718dd58b4967c5114342a86c/charts/year?currency=usd"
         },
         "data": {
           "type": "fungible_charts",
-          "id": "eth-year"
+          "id": "0x75231f58b43240c9718dd58b4967c5114342a86c-year"
         }
       }
     }
@@ -7015,14 +6724,14 @@
       "market_data": {
         "total_supply": 122373866.2178,
         "circulating_supply": 122373866.2178,
-        "market_cap": 377309223016.03186,
-        "fully_diluted_valuation": 377309223016.03186,
-        "price": 3083.25,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
         "changes": {
-          "percent_1d": -0.9823883051152342,
-          "percent_30d": 16.855282506859897,
-          "percent_90d": 16.28016609027858,
-          "percent_365d": 57.96471058375088
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
         }
       }
     },
@@ -7079,6 +6788,308 @@
         "data": {
           "type": "fungible_charts",
           "id": "eth-year"
+        }
+      }
+    }
+  },
+  "zora": {
+    "type": "fungibles",
+    "id": "eth",
+    "attributes": {
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "description": "Ethereum is a global, open-source platform for decentralized applications. In other words, the vision is to create a world computer that anyone can build applications in a decentralized manner; while all states and data are distributed and publicly accessible. Ethereum supports smart contracts in which developers can write code in order to program digital value. Examples of decentralized apps (dapps) built on Ethereum include token, non-fungible tokens, decentralized finance apps, lending protocol, decentralized exchanges, and much more.",
+      "icon": {
+        "url": "https://cdn.zerion.io/eth.png"
+      },
+      "flags": {
+        "verified": true
+      },
+      "external_links": [],
+      "implementations": [
+        {
+          "chain_id": "arbitrum",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "astar-zkevm",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "aurora",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "base",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "blast",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "bob",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "cyber",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "ethereum",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "linea",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "lisk",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "manta-pacific",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "mode",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "optimism",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "polygon-zkevm",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "polynomial",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "rari",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "redstone",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "scroll",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "taiko",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "world",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "zero",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "zklink-nova",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "zksync-era",
+          "address": null,
+          "decimals": 18
+        },
+        {
+          "chain_id": "zora",
+          "address": null,
+          "decimals": 18
+        }
+      ],
+      "market_data": {
+        "total_supply": 122373866.2178,
+        "circulating_supply": 122373866.2178,
+        "market_cap": 403865575723.95667,
+        "fully_diluted_valuation": 403865575723.95667,
+        "price": 3300.26,
+        "changes": {
+          "percent_1d": -1.8591760388726097,
+          "percent_30d": 29.97294412785179,
+          "percent_90d": 20.464151962680962,
+          "percent_365d": 58.9268945723518
+        }
+      }
+    },
+    "relationships": {
+      "chart_day": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth/charts/day?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "eth-day"
+        }
+      },
+      "chart_hour": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth/charts/hour?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "eth-hour"
+        }
+      },
+      "chart_max": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth/charts/max?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "eth-max"
+        }
+      },
+      "chart_month": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth/charts/month?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "eth-month"
+        }
+      },
+      "chart_week": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth/charts/week?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "eth-week"
+        }
+      },
+      "chart_year": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/eth/charts/year?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "eth-year"
+        }
+      }
+    }
+  },
+  "re-al": {
+    "type": "fungibles",
+    "id": "3b5814a4-7fa3-48e3-b389-638925def2cf",
+    "attributes": {
+      "name": "Real Ether",
+      "symbol": "reETH",
+      "description": null,
+      "icon": null,
+      "flags": {
+        "verified": false
+      },
+      "external_links": [],
+      "implementations": [
+        {
+          "chain_id": "ethereum",
+          "address": "0xc0cc5ea00cae0894b441e3b5a3bb57aa92f15421",
+          "decimals": 18
+        },
+        {
+          "chain_id": "re-al",
+          "address": null,
+          "decimals": 18
+        }
+      ],
+      "market_data": {
+        "total_supply": null,
+        "circulating_supply": null,
+        "market_cap": null,
+        "fully_diluted_valuation": null,
+        "price": 3348.546660048048,
+        "changes": {
+          "percent_1d": -1.860511677014547,
+          "percent_30d": null,
+          "percent_90d": null,
+          "percent_365d": null
+        }
+      }
+    },
+    "relationships": {
+      "chart_day": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/day?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-day"
+        }
+      },
+      "chart_hour": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/hour?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-hour"
+        }
+      },
+      "chart_max": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/max?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-max"
+        }
+      },
+      "chart_month": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/month?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-month"
+        }
+      },
+      "chart_week": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/week?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-week"
+        }
+      },
+      "chart_year": {
+        "links": {
+          "related": "https://api.zerion.io/v1/fungibles/3b5814a4-7fa3-48e3-b389-638925def2cf/charts/year?currency=usd"
+        },
+        "data": {
+          "type": "fungible_charts",
+          "id": "3b5814a4-7fa3-48e3-b389-638925def2cf-year"
         }
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -65,6 +65,7 @@ export class ZerionAPI implements iZerionAPI {
       await this.service.fetchFromZerion<FungiblePositionsResponse>(
         `/wallets/${walletAddress}/positions/?filter[positions]=${filterPositions}&currency=${currency}&filter[trash]=${filterTrash}&sort=${sort}`
       );
+
     return data;
   }
 
@@ -72,6 +73,18 @@ export class ZerionAPI implements iZerionAPI {
     const { data } = await this.service.fetchFromZerion<FungibleResponse>(
       `/fungibles/${id}`
     );
+    if (data.id === "7560001f-9b6d-4115-b14a-6c44c4334ef2") {
+      // Skip Recognition of MRC20 Token Contract:
+      // https://polygonscan.com/address/0x0000000000000000000000000000000000001010
+      // This token has a payable transfer function and messes shit up.
+      data.attributes.implementations = [
+        {
+          chain_id: "polygon",
+          address: null,
+          decimals: 18,
+        },
+      ];
+    }
     return data;
   }
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -28,18 +28,27 @@ describe("Near Safe Requests", () => {
   it.skip("getFungiblePositions", async () => {
     const zerion = new ZerionAPI(apiKey, false);
     const balances = await zerion.getFungiblePositions(
-      "0x8d99F8b2710e6A3B94d9bf465A98E5273069aCBd"
+      "0x54F08c27e75BeA0cdDdb8aA9D69FD61551B19BbA"
     );
     console.log("Balances", JSON.stringify(balances, null, 2));
   });
 
+  it.skip("fungibles", async () => {
+    const zerion = new ZerionAPI(apiKey, false);
+    const polygonNativeAsset = await zerion.fungibles(
+      "7560001f-9b6d-4115-b14a-6c44c4334ef2"
+    );
+    expect(polygonNativeAsset.attributes.implementations).toEqual([
+      { address: null, chain_id: "polygon", decimals: 18 },
+    ]);
+  });
   it.skip("ui.getUserBalances", async () => {
     const zerion = new ZerionAPI(apiKey, false);
     const balances = await zerion.ui.getUserBalances(
       "0x54F08c27e75BeA0cdDdb8aA9D69FD61551B19BbA",
       {
         options: {
-          supportedChains: [100],
+          supportedChains: [137, 100],
           // showZeroNative: true,
           // hideDust: 0.0001,
         },


### PR DESCRIPTION
Polygon has this [weird contract](https://polygonscan.com/address/0x0000000000000000000000000000000000001010) making its native asset into some kind of vague ERC20 token. Its an MRC20 and its transfer function is payable (unconventional). 

In order to skip/ignore dumb shit, we override the fungible to exclude/bypass this token contract.

It is technically possible to encode transfers through this however the transfer data must include "value" as well. 

### Native Asset Transfer ✅ 
[Example Tx](https://polygonscan.com/tx/0xd587a77ca672ab2adfafba7903bbc1bbb343667493a39db75994033101da181e)

```ts
{ 
  to: recipientAddress,
  value: weiAmount,
  data: "0x"
}
```

### ERC20 Transfer ❌ 
[Example Tx](https://polygonscan.com/tx/0x91c359ca17fadcb861bbe30f93dd24e48ade0b3fbae588b7a9250c4c46a8dd35)
without the `value` set, this transaction will success and result in a transfer of nothing.
```ts
{ 
  to: contractAddress,
  value: 0,
  data: encodeErc20Transfer(recipientAddress, weiAmount)
}
```


### MRC20 Transfer ✅ 

[Example Tx](https://polygonscan.com/tx/0xc25f35902b87e01bca74213c8a9c864faa2edd84d6a0f57069f26b2a42b884f6) 
```ts
{ 
  to: contractAddress,
  value: weiAmount,
  data: encodeErc20Transfer(recipientAddress, weiAmount)
}
```

But this would involve a special case in other places as well. I thought it would be most convenient to put the isolated special case deep down in this library so nobody ever has to think about it!



