### PR TITLE
Use ChainId as ChainIcon Keys

### DIFF
--- a/src/transform/ui.ts
+++ b/src/transform/ui.ts
@@ -67,7 +67,7 @@ export function transformPositionDataToUserDashboardResponse(
         return null;
       }
       chainsWithPositions.add(chain.zerionId);
-      chainsIcons[chain.name] = chain.icon!;
+      chainsIcons[chain.numberId] = chain.icon!;
       chainSet.add(chain.name);
 
       // Update total USD balance
@@ -122,7 +122,7 @@ export function transformPositionDataToUserDashboardResponse(
       const chain = chainMap.get(chainId);
       if (!chain || chainsWithPositions.has(chainId)) continue;
 
-      chainsIcons[chain.name] = chain.icon!;
+      chainsIcons[chain.numberId] = chain.icon!;
       chainSet.add(chain.name);
 
       tokens.push({
@@ -191,7 +191,7 @@ export function transformNftDataToUserNftResponse(
 
     const chain = chainsMap.get(nft.relationships.chain.data.id)!;
     chainsSet.add(chain.name);
-    chainsIcons[chain.name] = chain.icon;
+    chainsIcons[chain.numericId] = chain.icon;
 
     return {
       nft_contract_id: nft.attributes.nft_info.contract_address,

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -31,7 +31,7 @@ export type UserNft = {
   chain: string | null;
 };
 
-export type ChainIcons = { [key: string]: string };
+export type ChainIcons = { [key: number]: string };
 
 export type UserToken = {
   chain: UserTokenChain;

--- a/tests/unit/ui.spec.ts
+++ b/tests/unit/ui.spec.ts
@@ -348,9 +348,9 @@ describe("Near Safe Requests", () => {
     expect(uiBalances.chainsIcons).toStrictEqual({
       // Arbitrum: "https://chain-icons.s3.amazonaws.com/arbitrum.png",
       // Base: "https://chain-icons.s3.amazonaws.com/chainlist/8453",
-      Ethereum: "https://chain-icons.s3.amazonaws.com/ethereum.png",
+      1: "https://chain-icons.s3.amazonaws.com/ethereum.png",
       // "Gnosis Chain": "https://chain-icons.s3.amazonaws.com/xdai.png",
-      Optimism: "https://chain-icons.s3.amazonaws.com/optimism.png",
+      10: "https://chain-icons.s3.amazonaws.com/optimism.png",
       // Polygon: "https://chain-icons.s3.amazonaws.com/polygon.png",
     });
     expect(uiBalances.tokens).toStrictEqual([
@@ -402,9 +402,9 @@ describe("NFT Transformations", () => {
     expect(userNftResponse.chainsIcons).toStrictEqual({
       // Arbitrum: "https://chain-icons.s3.amazonaws.com/arbitrum.png",
       // Base: "https://chain-icons.s3.amazonaws.com/chainlist/8453",
-      Ethereum: "https://chain-icons.s3.amazonaws.com/ethereum.png",
+      1: "https://chain-icons.s3.amazonaws.com/ethereum.png",
       // "Gnosis Chain": "https://chain-icons.s3.amazonaws.com/xdai.png",
-      Optimism: "https://chain-icons.s3.amazonaws.com/optimism.png",
+      10: "https://chain-icons.s3.amazonaws.com/optimism.png",
       // Polygon: "https://chain-icons.s3.amazonaws.com/polygon.png",
     });
 


### PR DESCRIPTION
Changing the `ChainIcons` structure to use chainId instead of chainName as keys.

Closes #20 

