### PR TITLE
Fix Balance Precision

### DIFF
--- a/src/transform/ui.ts
+++ b/src/transform/ui.ts
@@ -88,7 +88,7 @@ export function transformPositionDataToUserDashboardResponse(
           ...(chainIcon ? { chainIcon } : {}),
         },
         balances: {
-          balance: attributes.quantity.float,
+          balance: attributes.quantity.numeric,
           // Testnet tokens are valueless we assign a fake value of 1.
           usdBalance: isTestnet
             ? attributes.quantity.float
@@ -132,7 +132,7 @@ export function transformPositionDataToUserDashboardResponse(
           ...(chain.icon ? { chainIcon: chain.icon } : {}),
         },
         balances: {
-          balance: 0,
+          balance: "0",
           usdBalance: 0,
           price: nativeToken.attributes.market_data?.price || 0,
         },

--- a/src/transform/ui.ts
+++ b/src/transform/ui.ts
@@ -88,7 +88,7 @@ export function transformPositionDataToUserDashboardResponse(
           ...(chainIcon ? { chainIcon } : {}),
         },
         balances: {
-          balance: attributes.quantity.numeric,
+          balance: Number(attributes.quantity.numeric),
           // Testnet tokens are valueless we assign a fake value of 1.
           usdBalance: isTestnet
             ? attributes.quantity.float
@@ -132,7 +132,7 @@ export function transformPositionDataToUserDashboardResponse(
           ...(chain.icon ? { chainIcon: chain.icon } : {}),
         },
         balances: {
-          balance: "0",
+          balance: 0,
           usdBalance: 0,
           price: nativeToken.attributes.market_data?.price || 0,
         },

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -45,7 +45,7 @@ export interface UserTokenChain {
   chainIcon?: string;
 }
 export interface UserTokenBalance {
-  balance: number;
+  balance: string;
   usdBalance: number;
   price?: number;
 }

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -45,7 +45,7 @@ export interface UserTokenChain {
   chainIcon?: string;
 }
 export interface UserTokenBalance {
-  balance: string;
+  balance: number;
   usdBalance: number;
   price?: number;
 }

--- a/tests/unit/ui.spec.ts
+++ b/tests/unit/ui.spec.ts
@@ -361,7 +361,7 @@ describe("Near Safe Requests", () => {
           chainIcon: "https://chain-icons.s3.amazonaws.com/optimism.png",
         },
         balances: {
-          balance: 2.5246051527348325,
+          balance: "2.524605152734832372",
           usdBalance: 6667.835653094075,
           price: 2641.14,
         },
@@ -380,7 +380,7 @@ describe("Near Safe Requests", () => {
           chainIcon: "https://chain-icons.s3.amazonaws.com/ethereum.png",
         },
         balances: {
-          balance: 5000,
+          balance: "5000.000000000000000000",
           usdBalance: 1387.2587850000002,
           price: 0.277451757,
         },

--- a/tests/unit/ui.spec.ts
+++ b/tests/unit/ui.spec.ts
@@ -361,7 +361,7 @@ describe("Near Safe Requests", () => {
           chainIcon: "https://chain-icons.s3.amazonaws.com/optimism.png",
         },
         balances: {
-          balance: "2.524605152734832372",
+          balance: 2.524605152734832372,
           usdBalance: 6667.835653094075,
           price: 2641.14,
         },
@@ -380,7 +380,7 @@ describe("Near Safe Requests", () => {
           chainIcon: "https://chain-icons.s3.amazonaws.com/ethereum.png",
         },
         balances: {
-          balance: "5000.000000000000000000",
+          balance: 5000,
           usdBalance: 1387.2587850000002,
           price: 0.277451757,
         },


### PR DESCRIPTION
number valued balance fields are essentially always wrong and shouldn't exist. Luckily Zerion returns a structured data type with the full precision already available; that is

```ts
"quantity": {
  "int": "8431170095597067",
  "decimals": 18,
  "float": 0.0084311700955971,
  "numeric": "0.008431170095597067"
}
```

So, this PR just changes the number type to string and uses the "numeric" value instead of the "float" value. 

This is an interface breaking change!



cc @rubenmarcus


## Update

We made a compromise so not to break the interface. This involves using the "numeric" field value, but casting back to Number. If necessary we can take this one step further, by returning the string field.
