### PR TITLE
Get Token by chainId & address

### DIFF
--- a/src/types/fungibles.ts
+++ b/src/types/fungibles.ts
@@ -61,3 +61,10 @@ export interface FungibleResponse {
   };
   data: FungibleTokenData;
 }
+
+export interface ListFungiblesResponse {
+  links: {
+    self: string;
+  };
+  data: FungibleTokenData[];
+}

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -22,6 +22,16 @@ describe.skip("Integration Test", () => {
     }
     return new ZerionAPI(apiKey, testnet);
   }
+
+  it("get token", async () => {
+    const zerion = loadZerion();
+    // DXD on Gnosis.
+    const token = await zerion.getToken({
+      chainId: 100,
+      address: "0xb90d6bec20993be5d72a5ab353343f7a0281f158",
+    });
+    console.log(JSON.stringify(token, null, 2));
+  });
   it("get testnet Chains", async () => {
     const zerion = loadZerion(true);
     const chains = await zerion.getChains();


### PR DESCRIPTION
Zerion assigns their own identifier to their tokens. We must first get them with `listFungibles`using the `address` and `zerionInternalChainName` as filters. This makes it easier for end users to just "get the flippin token"